### PR TITLE
added sequence-factory, some tests, fixed linting issues

### DIFF
--- a/example/make-manifest.js
+++ b/example/make-manifest.js
@@ -11,6 +11,6 @@
 var Manifest = require('../lib/manifest-factory.js');
 
 var m = new Manifest();
-m.canvases.push("Page 1");
+m.sequences.push("Sequence 1");
 
-console.log(m.getTotalCanvases()); // "1"
+console.log(m.getTotalSequences()); // "1"

--- a/lib/manifest-factory.js
+++ b/lib/manifest-factory.js
@@ -12,13 +12,13 @@ var _ = require('lodash');
 
 // Constructor
 var Manifest = function(id) {
-   this.id = (id ? id : _.uniqueId());
+  this.id = (id ? id : _.uniqueId());
 };
 // properties and methods
 Manifest.prototype = {
-  id: "123",
-  type: "sc:Manifest",
-  label: "untitled",
+  id: '123',
+  type: 'sc:Manifest',
+  label: 'untitled',
   sequences: [],
   getTotalSequences: function() {
     return this.sequences.length;

--- a/lib/sequence-factory.js
+++ b/lib/sequence-factory.js
@@ -1,5 +1,5 @@
 /*
- * manifest-factory
+ * sequence-factory
  * ient.github.io
  *
  * Copyright (c) 2015 Shaun Ellis
@@ -11,18 +11,18 @@
 var _ = require('lodash');
 
 // Constructor
-var Manifest = function(id) {
+var Sequence = function(id) {
    this.id = (id ? id : _.uniqueId());
-};
+}
 // properties and methods
-Manifest.prototype = {
+Sequence.prototype = {
   id: "123",
-  type: "sc:Manifest",
-  label: "untitled",
-  sequences: [],
-  getTotalSequences: function() {
-    return this.sequences.length;
+  type: "sc:Sequence",
+  label: "current page order",
+  canvases: [],
+  getTotalCanvases: function() {
+    return this.canvases.length;
   }
 };
 // node.js module export
-module.exports = Manifest;
+module.exports = Sequence;

--- a/lib/sequence-factory.js
+++ b/lib/sequence-factory.js
@@ -12,13 +12,13 @@ var _ = require('lodash');
 
 // Constructor
 var Sequence = function(id) {
-   this.id = (id ? id : _.uniqueId());
-}
+  this.id = (id ? id : _.uniqueId());
+};
 // properties and methods
 Sequence.prototype = {
-  id: "123",
-  type: "sc:Sequence",
-  label: "current page order",
+  id: '123',
+  type: 'sc:Sequence',
+  label: 'current page order',
   canvases: [],
   getTotalCanvases: function() {
     return this.canvases.length;

--- a/test/manifest-factory_test.js
+++ b/test/manifest-factory_test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Manifest = require('../lib/manifest-factory');
+var Sequence = require('../lib/sequence-factory');
 var assert = require('should');
 
 describe('Manifest Factory', function () {
@@ -13,5 +14,32 @@ describe('Manifest Factory', function () {
   it('should set a unique id if no id is specified', function () {
     var m = new Manifest();
   });
+
+  /*
+   * A manifest must have a type of sc:manifest that cannot be modified
+   */
+
+  /*
+   * The identifier in @id must always be able to be dereferenced to retrieve
+   * the JSON description of the manifest, and thus must use the http(s) URI
+   * scheme.
+   */
+
+   /*
+    * A manifest must contain one or more sequences
+    */
+    it('should contain one or more sequences', function () {
+      var m = new Manifest("http://123");
+      var s1 = new Sequence("http://456");
+      var s2 = new Sequence("http://789");
+      m.sequences.push(s1, s2);
+      m.getTotalSequences().should.equal(2);
+    });
+
+  /*
+   * Only one sequence may be embedded.  Any additional sequences must be
+   * referred to from the manifest, not embedded within it,
+   * and thus these additional sequences must have an HTTP URI.
+   */
 
 });

--- a/test/sequence-factory_test.js
+++ b/test/sequence-factory_test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var Sequence = require('../lib/sequence-factory');
+var assert = require('should');
+
+describe('Sequence Factory', function () {
+
+  it('should set an id from param', function () {
+    var s = new Sequence('456');
+    s.id.should.equal('456');
+  });
+
+  it('should set a unique id if no id is specified', function () {
+    var s = new Sequence();
+  });
+
+  /*
+   * A sequence must have a type of sc:sequence that cannot be modified
+   */
+
+  /*
+   * The identifier in @id must always be able to be dereferenced to retrieve
+   * the JSON description of the sequence, and thus must use the http(s) URI
+   * scheme.
+   */
+
+});


### PR DESCRIPTION
Very incremental update.  I plan to add basic resource type classes to manifesto just to scaffold it out just like I did with Sequence here.  I also plan to start stubbing commented out tests (see the test files) for each of these classes that match the Presentation API 2.0 spec requirements.  This will give us a roadmap and help others figure out where they might contribute.  I think it will be easier to organize this way initially, rather than creating github issues for every "MUST" in the spec.

Finally, I think we should probably use browserify to bundle all the dependencies so example files don't have to list every required module.  Thoughts?